### PR TITLE
Aggregation with different sizes

### DIFF
--- a/protocols/collective_aggregation_protocol.go
+++ b/protocols/collective_aggregation_protocol.go
@@ -9,7 +9,6 @@ package protocolsunlynx
 
 import (
 	"fmt"
-	"go.dedis.ch/kyber/v3"
 	"math"
 	"sync"
 	"time"
@@ -100,8 +99,6 @@ type CollectiveAggregationProtocol struct {
 	DataReferenceChannel chan dataReferenceStruct
 	LengthNodeChannel    chan []cadmbLengthStruct
 	ChildDataChannel     chan []childAggregatedDataBytesStruct
-
-	Pubkey kyber.Point
 
 	// Protocol state data
 	GroupedData *map[libunlynx.GroupingKey]libunlynx.FilteredResponse
@@ -243,7 +240,7 @@ func (p *CollectiveAggregationProtocol) ascendingAggregationPhase(cvMap map[libu
 					if len(localAggr.AggregatingAttributes) != len(aggr.Fr.AggregatingAttributes) {
 						encZeros := make(libunlynx.CipherVector, int(math.Abs(float64(len(localAggr.AggregatingAttributes)-len(aggr.Fr.AggregatingAttributes)))))
 						for e := range encZeros {
-							encZeros[e] = *libunlynx.EncryptInt(p.Pubkey, 0)
+							encZeros[e] = *libunlynx.EncryptInt(p.Roster().Aggregate, 0)
 						}
 						if len(localAggr.AggregatingAttributes) > len(aggr.Fr.AggregatingAttributes) {
 							aggr.Fr.AggregatingAttributes = append(aggr.Fr.AggregatingAttributes, encZeros...)


### PR DESCRIPTION
This was my take on issue #47.

What I did was to simply encrypt 0's and append them to the array during the aggregation. 

```golang 
if len(localAggr.AggregatingAttributes) != len(aggr.Fr.AggregatingAttributes) {
	encZeros := make(libunlynx.CipherVector, int(math.Abs(float64(len(localAggr.AggregatingAttributes)-len(aggr.Fr.AggregatingAttributes)))))
	for e := range encZeros {
		encZeros[e] = *libunlynx.EncryptInt(p.Roster().Aggregate, 0)
	}
	if len(localAggr.AggregatingAttributes) > len(aggr.Fr.AggregatingAttributes) {
		aggr.Fr.AggregatingAttributes = append(aggr.Fr.AggregatingAttributes, encZeros...)
	} else {
		localAggr.AggregatingAttributes = append(localAggr.AggregatingAttributes, encZeros...)
	}
}
```

To do this I need to pass the collective public key to the protocol, but this should be fine in Medco. I'll make a PR also there. 

@WiseIndian it was just this no or am I missing something?
